### PR TITLE
fix: was failing to create a new file because directory already exists

### DIFF
--- a/lua/ouroboros/init.lua
+++ b/lua/ouroboros/init.lua
@@ -83,7 +83,7 @@ function M.switch()
             return false
           else
             local path, filename, extension = utils.split_filename(input)
-            vim.fn.mkdir(path, "-p")
+            vim.fn.mkdir(path, "p")
             vim.cmd("edit " .. input)
             return true
           end


### PR DESCRIPTION
There was a bug/typo? or Neovim changed it's API, but `vim.fn.mkdir(path, "-p")` was failing, apparently the correct string is just `"p"`.