### PR TITLE
Use non-deprecated checkhealth syntax

### DIFF
--- a/autoload/health/ouroboros.vim
+++ b/autoload/health/ouroboros.vim
@@ -1,3 +1,0 @@
-function! health#ouroboros#check()
-  lua require 'ouroboros.health'.check()
-endfunction

--- a/lua/ouroboros/health.lua
+++ b/lua/ouroboros/health.lua
@@ -1,6 +1,6 @@
-local health_start = vim.fn["health#report_start"]
-local health_ok = vim.fn["health#report_ok"]
-local health_error = vim.fn["health#report_error"]
+local health_start = vim.health.start
+local health_ok = vim.health.ok
+local health_error = vim.health.error
 
 local required = {
   { lib = "plenary", optional = false },


### PR DESCRIPTION
Also remove autoload checkhealth files as they're redundant with the lua
checkhealth (:checkhealth command doesn't exist in vim).
