### PR TITLE
Minor changes to search behaviour

### DIFF
--- a/lua/ouroboros/init.lua
+++ b/lua/ouroboros/init.lua
@@ -106,7 +106,10 @@ function M.switch()
             else
                 local path, filename, extension = utils.split_filename(input)
                 vim.fn.mkdir(path, "p")
-                vim.cmd("edit " .. input)
+                local fname = input
+                vim.cmd("edit " .. fname)
+                -- store created file 
+                dict[filename .. current_file_extension] = fname
                 return true
             end
         end)

--- a/lua/ouroboros/init.lua
+++ b/lua/ouroboros/init.lua
@@ -45,7 +45,6 @@ function M.switch()
     end
 
     -- only do search logic if we did not already find a match earlier
-
     if not found_match then
         -- these are our scan options, refer to plenary.scan_dir for the options available here
         local scan_opts = {


### PR DESCRIPTION
Hi @jakemason,

A couple of minor changes:

1.  when searching for matches, search first in `path` before `.`.  This covers cases where `current_file` isn't in the project tree.
2.  if a new file is created, add it to the local cache so we don't need to search for it again later.

I hope the changes are clear enough; please let me know if you need any more info.