### PR TITLE
Minor change to skip score calculation for same file extensions

### DIFF
--- a/lua/ouroboros/init.lua
+++ b/lua/ouroboros/init.lua
@@ -55,7 +55,8 @@ function M.switch()
 
         -- search 1) in the same path as the original file, and then 2) in the project tree if we still haven't found a match
         for _, p in ipairs({path, '.'}) do
-        -- look for files that meet our above criteria
+        -- clean the path from extra slashes, then look for files that meet our above criteria
+            local clean_path = p:gsub("/$", "")
             local matching_files = scan.scan_dir(p, scan_opts)
 
             local next = next -- This is just an efficiency trick in Lua 
@@ -65,26 +66,32 @@ function M.switch()
             if next(matching_files) ~= nil then
                 for _, file_path in ipairs(matching_files) do
                     local _, _, file_extension = utils.split_filename(file_path)
-                    local score = utils.calculate_final_score(current_file, file_path, current_file_extension, file_extension)
-                    table.insert(scores, {path = file_path, score = score})
+
+                    if file_extension ~= current_file_extension then
+                        local score = utils.calculate_final_score(current_file, file_path, current_file_extension, file_extension)
+                        table.insert(scores, {path = file_path, score = score})
+                    end
                 end
 
-                table.sort(scores, function(a, b) return a.score > b.score end)
+                -- make sure the table isn't empty before we continue
+                if next(scores) ~= nil then
+                    table.sort(scores, function(a, b) return a.score > b.score end)
 
-                for _, item in ipairs(scores) do
-                    table.insert(sorted_matching_files, item.path)
-                end
+                    for _, item in ipairs(scores) do
+                        table.insert(sorted_matching_files, item.path)
+                    end
 
-                for _, item in ipairs(scores) do
-                    utils.log(string.format("File: %s, Score: %s", item.path, item.score))
-                end
+                    for _, item in ipairs(scores) do
+                        utils.log(string.format("File: %s, Score: %s", item.path, item.score))
+                    end
 
-                found_match = scores[1].score >= config.settings.score_required_to_be_confident_match_is_found
-                if found_match then
-                    match = scores[1].path
-                    -- store found file 
-                    dict[filename .. current_file_extension] = match
-                    break
+                    found_match = scores[1].score >= config.settings.score_required_to_be_confident_match_is_found
+                    if found_match then
+                        match = scores[1].path
+                        -- store found file 
+                        dict[filename .. current_file_extension] = match
+                        break
+                    end
                 end
             end
         end


### PR DESCRIPTION
Changed logic in M.switch() to skip checking scores for the same file extension (.cpp to .cpp and so on), which was causing early false positives.