### PR TITLE
Configure gitignore behavior

### DIFF
--- a/lua/ouroboros/config.lua
+++ b/lua/ouroboros/config.lua
@@ -11,7 +11,9 @@ local config = {
         switch_to_open_pane_if_possible = false,
         -- this number may need to be tweaked, will need to test drive
         -- for a while and see
-        score_required_to_be_confident_match_is_found = 10
+        score_required_to_be_confident_match_is_found = 10,
+
+        respect_gitignore = true,
     }
 }
 

--- a/lua/ouroboros/init.lua
+++ b/lua/ouroboros/init.lua
@@ -48,7 +48,7 @@ function M.switch()
     if not found_match then
         -- these are our scan options, refer to plenary.scan_dir for the options available here
         local scan_opts = {
-            respect_gitignore = true,
+			respect_gitignore = config.settings.respect_gitignore,
             -- Starts with anything but explicitly ends in "filename." (note the period is included!) 
             search_pattern = "^.*" .. filename .. "%..*$";
         }


### PR DESCRIPTION
I use a package manger that downloads sources to a local gitignored directory. Via language server navigations, I easily navigate to headers of dependencies. However, it would also be nice to then use ouroboros to quickly switch to the implementation if available. To achieve this, I disable respect_gitignore.